### PR TITLE
reducing criminal api hits

### DIFF
--- a/scripts/criminals/CriminalProvider.js
+++ b/scripts/criminals/CriminalProvider.js
@@ -15,7 +15,14 @@ export const useAssociates = criminalId => {
     .slice()
 };
 
-export const getCriminals = () => {
+/**
+ * Get criminals from glassdale API if not already loaded into application state.
+ * @param {boolean} force Set to true to force reloading criminals from external API, otherwise function will first check if criminals already loaded from API and will not reload if already loaded in.
+ */
+export const getCriminals = (force = false) => {
+  if(criminals.length && force !== true) {
+    return Promise.resolve(); // to allow .then() chaining to still work with this function
+  }
   return fetch('https://criminals.glassdale.us/criminals')
     .then(res => res.json())
     .then(criminalsData => criminals = criminalsData);


### PR DESCRIPTION
1. Verify that everything still works. 🤠 
1. Verify that only one `/criminals` API hit will happen in the current flow. Even though CriminalList, NoteList, and NoteForm all are calling `getCriminals`, the call to the external `criminals.glassdale.us` API should only happen once.